### PR TITLE
Fix date-parsing being one month ahead instead of the same month

### DIFF
--- a/pages/resume.vue
+++ b/pages/resume.vue
@@ -26,9 +26,9 @@ const { data: skills } = await useFetch('/api/skills')
             {{ work.title[locale] }}
           </h4>
           <span class="timeline-date">
-            {{ new Date(work.dateFrom.year, work.dateFrom.month, work.dateFrom.day).toLocaleDateString(locale) }}
+            {{ new Date(work.dateFrom.year, work.dateFrom.month - 1, work.dateFrom.day).toLocaleDateString(locale) }}
             —
-            {{ new Date(work.dateTo.year, work.dateTo.month, work.dateTo.day).toLocaleDateString(locale) }}</span>
+            {{ new Date(work.dateTo.year, work.dateTo.month - 1, work.dateTo.day).toLocaleDateString(locale) }}</span>
           <h5 class="h4 timeline-item-title">
             <span>
               <a :href="work.website[locale]" target="_blank">{{ work.employer[locale] }} 🌐</a>


### PR DESCRIPTION
`Date.toLocaleDateString` expects a month **index** unlike the year and day. Therefore, `0` is `January` while `11` is `December`.