### PR TITLE
Fixed percy snapshots timing out

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -42,23 +42,24 @@ jobs:
       run: npx playwright install --with-deps
       # if: steps.playwright-cache.outputs.cache-hit != 'true'
 
-    - name: Running Playwright tests on Preview
-      run: npm test
+    - name: Set Site URL for Preview
+      run: echo "NUXT_PUBLIC_SITE_URL=$SITE_URL" >> $GITHUB_ENV
       if: (github.ref_name == 'develop' || github.base_ref == 'develop' || github.base_ref == 'main') && github.event.pull_request.merged == false
       env:
-        NUXT_PUBLIC_SITE_URL: ${{ secrets.PREVIEW_URL }}
+        SITE_URL: ${{ secrets.PREVIEW_URL }}
 
-    - name: Running Playwright tests on Main
-      run: npm test
+    - name: Set Site URL for Main
+      run: echo "NUXT_PUBLIC_SITE_URL=$SITE_URL" >> $GITHUB_ENV
       if: github.ref_name == 'main' && github.event.pull_request.merged == true
       env:
-        NUXT_PUBLIC_SITE_URL: ${{ vars.SITE_URL }}
+        SITE_URL: ${{ vars.SITE_URL }}
+
+    - name: Running Playwright tests
+      run: npm test
 
     - name: Run Percy regression tests
       run: npm run percy
-      if: github.ref_name == 'main' || github.ref_name == 'develop'
       env:
-        NUXT_PUBLIC_SITE_URL: ${{ vars.SITE_URL }}
         PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -47,11 +47,16 @@ jobs:
       if: (github.ref_name == 'develop' || github.base_ref == 'develop' || github.base_ref == 'main') && github.event.pull_request.merged == false
       env:
         NUXT_PUBLIC_SITE_URL: ${{ secrets.PREVIEW_URL }}
-        PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
     - name: Running Playwright tests on Main
       run: npm test
       if: github.ref_name == 'main' && github.event.pull_request.merged == true
+      env:
+        NUXT_PUBLIC_SITE_URL: ${{ vars.SITE_URL }}
+
+    - name: Run Percy regression tests
+      run: npm run percy
+      if: github.ref_name == 'main' || github.ref_name == 'develop'
       env:
         NUXT_PUBLIC_SITE_URL: ${{ vars.SITE_URL }}
         PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.percy.yml
+++ b/.percy.yml
@@ -11,7 +11,7 @@ snapshot:
 discovery:
   allowedHostnames: []
   disallowedHostnames: []
-  networkIdleTimeout: 1000
+  networkIdleTimeout: 500
 upload:
   files: "**/*.{png,jpg,jpeg}"
   ignore: ""

--- a/components/CookieBar.vue
+++ b/components/CookieBar.vue
@@ -10,9 +10,9 @@ onMounted(() => {
 
 <template>
   <Transition name="bounce">
-    <div v-show="!cookie.getCookie" class="container left-0 right-0 mx-auto child md:w-[25%] bg-[#3f3f40] rounded-lg shadow-xl px-6 py-3 bottom-20 fixed z-[100] flex items-center justify-between animate-bounce">
+    <div data-testid="cookie-bar" v-show="!cookie.getCookie" class="container left-0 right-0 mx-auto child md:w-[25%] bg-[#3f3f40] rounded-lg shadow-xl px-6 py-3 bottom-20 fixed z-[100] flex items-center justify-between animate-bounce">
       <span class="text-[#fafafa]">This site use cookies (I wanted to use use ice cream but cookies were all I had.) 🍪</span>
-      <span class="cursor-pointer p-2 shadow-md rounded bg-[#383838] text-[#fafafa] hover:bg-[#1e1e1f] transition" @click="cookie.setCookie()">
+      <span data-testid="cookie-dismiss" class="cursor-pointer p-2 shadow-md rounded bg-[#383838] text-[#fafafa] hover:bg-[#1e1e1f] transition" @click="cookie.setCookie()">
         <ion-icon name="close-outline" />
       </span>
     </div>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "generate-gh": "NITRO_PRESET=github-pages nuxi generate",
     "generate-cf": "NITRO_PRESET=cloudflare_pages nuxi generate",
     "test": "playwright test",
-    "percy": "percy exec -- node take-snapshot.ts"
+    "percy": "percy exec -- node take-snapshots.ts"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.39.5",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "generate": "nuxi generate",
     "generate-gh": "NITRO_PRESET=github-pages nuxi generate",
     "generate-cf": "NITRO_PRESET=cloudflare_pages nuxi generate",
-    "test": "percy exec -- playwright test"
+    "test": "playwright test",
+    "percy": "percy exec -- node take-snapshot.ts"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^0.39.5",

--- a/take-snapshots.ts
+++ b/take-snapshots.ts
@@ -1,0 +1,24 @@
+const { chromium, expect } = require('@playwright/test');
+const percySnapshot = require('@percy/playwright');
+const url = require('url');
+
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  const baseUrl = process.env.NUXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+  
+  await page.goto(baseUrl, { waitUntil: 'networkidle' });
+  
+  await page.getByTestId(/cookie-dismiss/).click({ force: true });
+  await expect(page.getByTestId(/cookie-dismiss/)).not.toBeVisible()
+
+  await percySnapshot(page, 'About Me Page');
+
+  await page.goto(new URL('/resume', baseUrl).toString());
+  await percySnapshot(page, 'Resume Page');
+
+  await page.goto(new URL('/portfolio', baseUrl).toString());
+  await percySnapshot(page, 'Portfolio Page');
+
+  await browser.close();
+})();

--- a/tests/about.spec.ts
+++ b/tests/about.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '@playwright/test';
-import percySnapshot from '@percy/playwright'
 
 test.beforeEach(async ({ page }) => {
     await page.goto('/')
@@ -8,7 +7,3 @@ test.beforeEach(async ({ page }) => {
 test('url is as expected', async ({ page }) => {
   await expect(page).toHaveTitle(/About me/)
 });
-
-test('percy snapshot', async ({ page, browserName }) => {
-    await percySnapshot(page, `About page ${browserName}`)
-})

--- a/tests/portfolio.spec.ts
+++ b/tests/portfolio.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '@playwright/test';
-import percySnapshot from '@percy/playwright'
 
 test.beforeEach(async ({ page }) => {
     await page.goto('/portfolio')
@@ -7,8 +6,4 @@ test.beforeEach(async ({ page }) => {
 
 test('url is as expected', async ({ page }) => {
   await expect(page).toHaveTitle(/Portfolio/);
-})
-
-test('percy snapshot', async ({ page, browserName }) => {
-  await percySnapshot(page, `Portfolio page ${browserName}`)
 })

--- a/tests/resume.spec.ts
+++ b/tests/resume.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '@playwright/test';
-import percySnapshot from '@percy/playwright'
 
 test.beforeEach(async ({ page }) => {
     await page.goto('/resume')
@@ -8,7 +7,3 @@ test.beforeEach(async ({ page }) => {
 test('url is as expected', async ({ page }) => {
   await expect(page).toHaveTitle(/Resume/);
 });
-
-test('percy snapshot', async ({ page, browserName }) => {
-  await percySnapshot(page, `Resume page ${browserName}`)
-})


### PR DESCRIPTION
Percy now runs separately from Playwright tests.
`take-snapshots.ts` now performs all the necessary snapshot-taking.